### PR TITLE
Patch to avoid re-parsing script on atime change

### DIFF
--- a/lib/watchr/controller.rb
+++ b/lib/watchr/controller.rb
@@ -59,7 +59,7 @@ module Watchr
       path = Pathname(path).expand_path
 
       Watchr.debug("received #{event_type.inspect} event for #{path.relative_path_from(Pathname(Dir.pwd))}")
-      if path == @script.path
+      if path == @script.path && event_type != :accessed
         @script.parse!
         @handler.refresh(monitored_paths)
       else

--- a/test/test_controller.rb
+++ b/test/test_controller.rb
@@ -109,5 +109,13 @@ class TestController < MiniTest::Unit::TestCase
     @handler.stubs(:listen).raises(Interrupt)
     @controller.run
   end
+
+  test "does not parse script on mere script file access" do
+    path = to_p('abc')
+    @script.stubs(:path).returns(path)
+    @script.expects(:parse!).never
+
+    @controller.update('abc', :accessed)
+  end
 end
 


### PR DESCRIPTION
Hi, here's a small fix for that issue.
My scripts usually do an action (like run tests a first time) when parsed, and I was getting tired of that getting run twice when I changed the script.
I'm running watchr under Windows btw. And I love it !
-Jonathan
