### PR TITLE
Updated references from Rev to Coolio.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Install
 
     gem install watchr
 
-If you're on Linux/BSD and have the [rev][4] gem installed, Watchr will detect
+If you're on Linux/BSD and have the [cool.io][4] gem installed, Watchr will detect
 it and use it automatically. This will make Watchr evented.
 
-    gem install rev
+    gem install coolio
 
 You can get the same evented behaviour on OS X by installing
 [ruby-fsevent][10].
@@ -109,7 +109,7 @@ Links
 [1]:  http://github.com/mynyml/watchr/blob/master/specs.watchr
 [2]:  http://github.com/mynyml/watchr/blob/master/docs.watchr
 [3]:  http://github.com/mynyml/watchr/blob/master/gem.watchr
-[4]:  http://github.com/tarcieri/rev/
+[4]:  https://github.com/tarcieri/cool.io
 [5]:  http://wiki.github.com/mynyml/watchr
 [6]:  http://github.com/mynyml/redgreen
 [7]:  http://github.com/mynyml/phocus

--- a/lib/watchr.rb
+++ b/lib/watchr.rb
@@ -24,10 +24,10 @@ module Watchr
   end
 
   begin
-    require 'rev'
-    HAVE_REV = true
+    require 'coolio'
+    HAVE_COOLIO = true
   rescue LoadError, RuntimeError
-    HAVE_REV = false
+    HAVE_COOLIO = false
   end
 
   autoload :Script,     'watchr/script'
@@ -36,7 +36,7 @@ module Watchr
   module EventHandler
     autoload :Base,     'watchr/event_handlers/base'
     autoload :Portable, 'watchr/event_handlers/portable'
-    autoload :Unix,     'watchr/event_handlers/unix'      if ::Watchr::HAVE_REV
+    autoload :Unix,     'watchr/event_handlers/unix'      if ::Watchr::HAVE_COOLIO
     autoload :Darwin,   'watchr/event_handlers/darwin'    if ::Watchr::HAVE_FSE
   end
 
@@ -117,10 +117,10 @@ module Watchr
               Watchr::EventHandler::Portable
             end
           when /sunos|solaris|bsd|linux|unix/i
-            if Watchr::HAVE_REV
+            if Watchr::HAVE_COOLIO
               Watchr::EventHandler::Unix
             else
-              Watchr.debug "rev not found. `gem install rev` to get evented handler"
+              Watchr.debug "coolio not found. `gem install coolio` to get evented handler"
               Watchr::EventHandler::Portable
             end
           when /mswin|windows|cygwin/i

--- a/lib/watchr/event_handlers/unix.rb
+++ b/lib/watchr/event_handlers/unix.rb
@@ -3,11 +3,11 @@ module Watchr
     class Unix
       include Base
 
-      # Used by Rev. Wraps a monitored path, and `Rev::Loop` will call its
+      # Used by Coolio. Wraps a monitored path, and `Coolio::Loop` will call its
       # callback on file events.
       #
       # @private
-      class SingleFileWatcher < Rev::StatWatcher
+      class SingleFileWatcher < Coolio::StatWatcher
         class << self
           # Stores a reference back to handler so we can call its {Base#notify notify}
           # method with file event info
@@ -75,7 +75,7 @@ module Watchr
 
       def initialize
         SingleFileWatcher.handler = self
-        @loop = Rev::Loop.default
+        @loop = Coolio::Loop.default
       end
 
       # Enters listening loop. Will block control flow until application is

--- a/test/event_handlers/test_unix.rb
+++ b/test/event_handlers/test_unix.rb
@@ -1,6 +1,6 @@
 require 'test/test_helper'
 
-if Watchr::HAVE_REV
+if Watchr::HAVE_COOLIO
 
 class Watchr::EventHandler::Unix::SingleFileWatcher
   public :type
@@ -20,7 +20,7 @@ class UnixEventHandlerTest < MiniTest::Unit::TestCase
     pathname.stubs(:exist?).returns(true)
     SingleFileWatcher.any_instance.stubs(:pathname).returns(pathname)
 
-    @loop    = Rev::Loop.default
+    @loop    = Coolio::Loop.default
     @handler = EventHandler::Unix.new
     @watcher = SingleFileWatcher.new('foo/bar')
     @loop.stubs(:run)
@@ -28,7 +28,7 @@ class UnixEventHandlerTest < MiniTest::Unit::TestCase
 
   def teardown
     SingleFileWatcher.handler = nil
-    Rev::Loop.default.watchers.every.detach
+    Coolio::Loop.default.watchers.every.detach
   end
 
   test "triggers listening state" do
@@ -159,4 +159,4 @@ class UnixEventHandlerTest < MiniTest::Unit::TestCase
   end
 end
 
-end  # if Watchr::HAVE_REV
+end  # if Watchr::HAVE_COOLIO

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,8 +27,8 @@ class MiniTest::Unit::TestCase
   end
 end
 
-unless Watchr::HAVE_REV
-  puts "Skipping Unix handler tests. Install Rev (gem install rev) to properly test full suite"
+unless Watchr::HAVE_COOLIO
+  puts "Skipping Unix handler tests. Install Coolio (gem install coolio) to properly test full suite"
 end
 
 unless Watchr::HAVE_FSE

--- a/test/test_watchr.rb
+++ b/test/test_watchr.rb
@@ -24,7 +24,7 @@ class TestWatchr < MiniTest::Unit::TestCase
 
   test "picking handler" do
 
-    if Watchr::HAVE_REV
+    if Watchr::HAVE_COOLIO
 
     Watchr.handler = nil
     ENV['HANDLER'] = 'linux'

--- a/watchr.gemspec
+++ b/watchr.gemspec
@@ -1,4 +1,4 @@
-require 'lib/watchr'
+require './lib/watchr'
 
 Gem::Specification.new do |s|
   s.name                = "watchr"


### PR DESCRIPTION
Tests are passing under mri 1.8.7 and 1.9.2, but I didn't actually use it under anything else then 1.9.2 yet.

Besides I made the require in watchr.gemspec explicitly relative to get it to build under ruby 1.9.
Though I hope there's a better way to do this.
