### PR TITLE
Do not reparse script when its deleted

### DIFF
--- a/lib/watchr/controller.rb
+++ b/lib/watchr/controller.rb
@@ -59,7 +59,7 @@ module Watchr
       path = Pathname(path).expand_path
 
       Watchr.debug("received #{event_type.inspect} event for #{path.relative_path_from(Pathname(Dir.pwd))}")
-      if path == @script.path && event_type != :accessed
+      if path == @script.path && (event_type != :accessed && event_type != :deleted)
         @script.parse!
         @handler.refresh(monitored_paths)
       else

--- a/test/test_controller.rb
+++ b/test/test_controller.rb
@@ -117,5 +117,13 @@ class TestController < MiniTest::Unit::TestCase
 
     @controller.update('abc', :accessed)
   end
+  
+  test "does not parse script on deletion" do
+    path = to_p('abc')
+    @script.stubs(:path).returns(path)
+    @script.expects(:parse!).never
+
+    @controller.update('abc', :deleted)
+  end
 end
 


### PR DESCRIPTION
When using the `-e` flag, a [Tempfile is created](https://github.com/mynyml/watchr/blob/master/bin/watchr#L94). This tempfile will be deleted once ruby GCs (as no reference to the tempfile is held anywhere), which will cause a `:deleted` event.

Once that happens, watchr will try to reparse the script, going into an endless loop because of [a retry call in script.rb](https://github.com/mynyml/watchr/blob/master/lib/watchr/script.rb#L176), receiving no further events.

This is only a possible solution to it; another option is to store the tempfile in a global variable (to avoid it ever getting GCd, and thus it will be never deleted). Doing it this way won’t guard against the file getting deleted by some other means, however.

Another way would be to [finish the noted todo](https://github.com/mynyml/watchr/blob/master/lib/watchr/script.rb#L170) in script.rb, but I don’t know the complications so I decided not to try that :)
