### PR TITLE
Fix deprecation warnings under 1.9.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ namespace(:test) do
 
   desc "Run all tests on multiple ruby versions (requires rvm)"
   task(:portability) do
-    %w( 1.8.6  1.8.7  1.9.1  1.9.2 ).each do |version|
+    %w( 1.8.6  1.8.7  1.9.1  1.9.2  1.9.3 ).each do |version|
       system <<-BASH
         bash -c 'source ~/.rvm/scripts/rvm;
                  rvm #{version};

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ end
 
 def ruby
   require 'rbconfig'
-  File.join([Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name']]) << Config::CONFIG['EXEEXT']
+  File.join([RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']]) << RbConfig::CONFIG['EXEEXT']
 end
 
 # --------------------------------------------------

--- a/lib/watchr.rb
+++ b/lib/watchr.rb
@@ -108,7 +108,7 @@ module Watchr
     #
     def handler
       @handler ||=
-        case ENV['HANDLER'] || Config::CONFIG['host_os']
+        case ENV['HANDLER'] || RbConfig::CONFIG['host_os']
           when /darwin|mach|osx|fsevents?/i
             if Watchr::HAVE_FSE
               Watchr::EventHandler::Darwin


### PR DESCRIPTION
Now that 1.9.3 is getting more traction, it's important to test using it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mynyml/watchr/42)
<!-- Reviewable:end -->
