### PR TITLE
Fixed that #to_set isn't defined unless we load the Set library

### DIFF
--- a/test/event_handlers/test_unix.rb
+++ b/test/event_handlers/test_unix.rb
@@ -1,4 +1,5 @@
 require 'test/test_helper'
+require 'set'
 
 if Watchr::HAVE_REV
 


### PR DESCRIPTION
I hit that when I was running under 1.8.7 with the rev gem on the
$LOAD_PATH.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mynyml/watchr/43)
<!-- Reviewable:end -->
