### PR TITLE
Adds RbConfig class to remove deprecation warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,8 @@ end
 
 def ruby
   require 'rbconfig'
-  File.join([Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name']]) << Config::CONFIG['EXEEXT']
+  conf = Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG 
+  File.join([conf['bindir'], conf['ruby_install_name']]) << conf['EXEEXT']
 end
 
 # --------------------------------------------------

--- a/lib/watchr.rb
+++ b/lib/watchr.rb
@@ -107,8 +107,9 @@ module Watchr
     #   handler class for current architecture
     #
     def handler
+      conf = Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG
       @handler ||=
-        case ENV['HANDLER'] || Config::CONFIG['host_os']
+        case ENV['HANDLER'] || conf['host_os']
           when /darwin|mach|osx|fsevents?/i
             if Watchr::HAVE_FSE
               Watchr::EventHandler::Darwin


### PR DESCRIPTION
Since Ruby 1.9.1, the Config class should be renamed to RbConfig. This
commit adds that but also leaves the old Config for olders Ruby
versions.
