### PR TITLE
Fix deprecation warning: 'Use RbConfig instead of obsolete and deprecate...

### DIFF
--- a/lib/watchr.rb
+++ b/lib/watchr.rb
@@ -108,7 +108,7 @@ module Watchr
     #
     def handler
       @handler ||=
-        case ENV['HANDLER'] || Config::CONFIG['host_os']
+        case ENV['HANDLER'] || RbConfig::CONFIG['host_os']
           when /darwin|mach|osx|fsevents?/i
             if Watchr::HAVE_FSE
               Watchr::EventHandler::Darwin


### PR DESCRIPTION
Fix deprecation warning: 'Use RbConfig instead of obsolete and deprecated Config.'
