### PR TITLE
Use RbConfig instead of obsolute and deprecated Config when defined

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,8 @@ end
 
 def ruby
   require 'rbconfig'
-  File.join([Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name']]) << Config::CONFIG['EXEEXT']
+  cfg = (defined?(RbConfig) ? RbConfig : Config)
+  File.join([cfg::CONFIG['bindir'], cfg::CONFIG['ruby_install_name']]) << cfg::CONFIG['EXEEXT']
 end
 
 # --------------------------------------------------

--- a/lib/watchr.rb
+++ b/lib/watchr.rb
@@ -107,8 +107,9 @@ module Watchr
     #   handler class for current architecture
     #
     def handler
+      cfg = defined?(RbConfig) ? RbConfig : Config
       @handler ||=
-        case ENV['HANDLER'] || Config::CONFIG['host_os']
+        case ENV['HANDLER'] || cfg::CONFIG['host_os']
           when /darwin|mach|osx|fsevents?/i
             if Watchr::HAVE_FSE
               Watchr::EventHandler::Darwin


### PR DESCRIPTION
This will use RbConfig but will fallback to Config if RbConfig is not defined
